### PR TITLE
BeautifulSoup is throwing a warning because of the parser

### DIFF
--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -42,7 +42,7 @@ class OpenGraph(object):
         return response.text
 
     def _parse(self, html):
-        doc = BeautifulSoup(html)
+        doc = BeautifulSoup(html, 'html.parser')
         ogs = doc.html.head.findAll(property=re.compile(r'^og'))
 
         for og in ogs:


### PR DESCRIPTION
UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.
