### PR TITLE
Various fixes

### DIFF
--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -39,7 +39,7 @@ class OpenGraph(object):
         return response.text
 
     def _parse(self, html):
-        doc = BeautifulSoup(html)
+        doc = BeautifulSoup(html, 'html.parser')
         ogs = doc.html.head.findAll(property=re.compile(r'^og'))
 
         for og in ogs:

--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -8,12 +8,9 @@ from bs4 import BeautifulSoup
 
 
 class OpenGraph(object):
-    useragent = None
-    __data__ = {}
-
     def __init__(self, url=None, html=None, useragent=None):
-        if useragent:
-            self.useragent = useragent
+        self.useragent = useragent
+        self.__data__ = {}
         content = html or self._fetch(url)
         self._parse(content)
 

--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -45,3 +45,7 @@ class OpenGraph(object):
         for og in ogs:
             if og.has_attr('content'):
                 self.__data__[og['property'][3:]] = og['content']
+
+    @property
+    def data(self):
+        return self.__data__


### PR DESCRIPTION
1. Moved `__data__` and `useragent` attributes into the instance scope so that they aren't shared by all instances of `OpenGraph`
2. Fix warning thrown by `BeautifulSoup` by providing appropriate initialization parameter
3. Add a property to return the `__data__` dictionary.
